### PR TITLE
Add rangePlugin (two input date range) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,66 +28,100 @@ Create a text field with input validation date, time or date and time and check 
 
 Create a filter element of type date, datetime, time or text and check 'Activate flatpickr'. You can also activate flatpickr and pass additional options from dca. See chapter dca configuration for more information. Flatpickr bundle checks the corresponding field dca configuration for filter elements.
 
-### Other frontend forms
+### DCA / Other frontend forms
 
-Other frontend form systems may work (like [formhybrid](https://github.com/heimrichhannot/contao-formhybrid)), if the form widgets are processed by the getAttributesFromDca hook. You need to activate flatpickr in your dca field configuration (see dca configuration chapter) and activate flatpickr on page level (layout section). The configuration is inherited but can be overridden.
+Other frontend form systems may work (like [formhybrid](https://github.com/heimrichhannot/contao-formhybrid)), if the form widgets are processed by the getAttributesFromDca hook. You need to activate flatpickr in your dca field configuration and activate flatpickr on page level (layout section). The configuration is inherited but can be overridden.
 
-## DCA configuration
+To actived flatpickr for a dca field, set `field.eval.flatpickr.active` to `true`.
 
-To add flatpickr to an input, set datepicker for your fields in dca to true. You can switch between datepicker, timepicker and datetimepicker by setting the corresponding format in the 'rgxp' setting.
-
-Following additional evaluation fields are added to configure flatpickr:
-
-Option                                              | Type   | Default | Description
---------------------------------------------------- | ------ | ------- | -----------
-field.eval.flatpickr                                | array  |         | Configuration of additional flatpickr options, implemented only by this bundle
-field.eval.flatpickr.active                         | bool   | false   | Activate additional flatpickr configuration
-field.eval.flatpickr.options                        | array  |         | Additional configuration options
-field.eval.flatpickr.options.incrementArrows        | array  |         | Append and prepend arrow buttons to increment/decrement date/time by defined amount
-field.eval.flatpickr.options.incrementArrows.unit   | string |         | Unit of time to increment/decrement by. **Valid values:** years, months, days, hours, minutes, seconds
-field.eval.flatpickr.options.incrementArrows.amount | int    |         | The value of time to increment/decrement by.
-field.eval.flatpickr.options.minDate                | string |         | A formatted date/time constraining the date/time picker to a certain minimum date/time.
-field.eval.flatpickr.options.maxDate                | string |         | A formatted date/time constraining the date/time picker to a certain maximum date/time.
-field.eval.flatpickr.options.prependPicker      | bool   | false   | Prepend date picker button instead of append it.
-field.eval.flatpickr.options.enableAmPm             | bool   | false   | Display a AM/PM selector instead of using 24 hr format.
-field.eval.flatpickr.options.customBtnTpl           | string |         | Bet custom template for flatpickr button. Type in template name (eg. btn_datepicker)
-
-It is also possible to use plugins. Only one plugin is currently implemented: <b>monthSelectPlugin</b>
-Plugins can be activated over dca configuration:
-
-Option                                              | Type   | Default | Description
---------------------------------------------------- | ------ | ------- | -----------
-field.eval.flatpickr.plugins.monthSelectPlugin      | array  |         | Configuration of additional flatpickr options, implemented only by this bundle
-
-the plugin configuration from https://flatpickr.js.org/plugins/#monthselectplugin is supported.
-
-It is also possible to disable months for each year with(<i>see example below</i>):
-field.eval.flatpickr.plugins.monthSelectPlugin.disabledMonths
-
-#### Example
 ```php
-    'fieldName' => [
-        'eval' = [
-            'flatpickr' => [ 
-                'active' => true,
-                'options' => [
-                    'minDate' => '09.09.2020',
-                    'maxDate' => '29.09.2020',
-                    'incrementArrows' => [
-                        'unit' => 'days',
-                        'amount' => 1,
-                    ],
-                ],
-                'plugins' => [
-                    'monthSelectPlugin' => [
-                        'horthand' => true,
-                        'dateFormat' => "M Y",
-                        'disabledMonths' => [2021 => [0,3,6]]
-                    ]
-                ]
-            ]
-        ]
-    ]
+$GLOBALS['TL_DCA']['tl_content']['fields']['date']['eval']['flatpickr']['active'] = true;
+```
+
+You can customize the picker type with `rgxp` eval option and pass additional flatpickr configuration:
+
+```php
+$GLOBALS['TL_DCA']['tl_content']['fields']['date'] = [
+    'eval' => [
+        'rgxp' => 'datim' # one of 'date', 'time' or 'datim'
+        'flatpickr' => [
+            'active' => true,
+            'options' => [], // Pass addtional flatpickr option, see configuration chapter
+            'plugins' => [], // Use and configure flatpickr plugins, see configuration chapter
+          ],
+    ]   
+];
+```
+
+## Configuration
+
+If flatpickr is activated for a field, it already works "out-of-the-box". Sometime additional customization are needed.
+
+### Flatpickr picker type
+
+Three picker types are supported: date, time and datetime.
+The types are automatically selected by setting the `rgxp` value to one of 'date', 'time' or 'datim'
+
+```php
+$field['eval']['rgxp'] = 'time'
+```
+
+### Custom configuration
+
+The most config options from flatpickr should work with this bundle.
+
+These options can be set from:
+* DCA (works for filter bundle and other frontend forms): Add the configuration to `$field['eval']['flatpickr']['options']`
+* php event (work with all types): See developers chapter
+* javascript event (work with all type): see developers chapter
+
+Typical configuration options:
+
+| Option    | Type   | Default | Description                                                                             |
+|-----------|--------|---------|-----------------------------------------------------------------------------------------|
+| minDate   | string |         | A formatted date/time constraining the date/time picker to a certain minimum date/time. |
+| maxDate   | string |         | A formatted date/time constraining the date/time picker to a certain maximum date/time. |
+| time_24hr | bool   | true    | Disable to display a AM/PM selector instead of using 24 hr format.                      |
+
+
+Following additional configuration are available from this bundle:
+
+| Option                 | Type   | Default | Description                                                                                            |
+|------------------------|--------|---------|--------------------------------------------------------------------------------------------------------|
+| incrementArrows        | array  |         | Append and prepend arrow buttons to increment/decrement date/time by defined amount                    |
+| incrementArrows.unit   | string |         | Unit of time to increment/decrement by. **Valid values:** years, months, days, hours, minutes, seconds |
+| incrementArrows.amount | int    |         | The value of time to increment/decrement by.                                                           |
+| prependPicker          | bool   | false   | Prepend date picker button instead of append it.                                                       |
+| customBtnTpl           | string |         | Bet custom template for flatpickr button. Type in template name (eg. btn_datepicker)                   |
+
+### Plugins
+
+Flatpickr can be extended with plugins. Plugins supported by this bundle can by activated and configured from `$field['eval']['flatpickr']['plugins']`.
+
+#### monthSelectPlugin
+
+[monthSelectPlugin](https://flatpickr.js.org/plugins/#monthselectplugin) shows a month-only calendar view. Additional to the default configuration options of the plugin
+there is an addition `disabledMonths` option.
+
+Example: 
+
+```php
+$GLOBALS['TL_DCA']['tl_content']['fields']['date']['eval']['flatpickr']['plugins']['monthSelectPlugin'] = [
+    'shorthand' => true,
+    'dateFormat' => "M Y",
+    'disabledMonths' => [2021 => [0,3,6]]
+];
+```
+
+#### rangePlugin
+
+[rangePlugin](https://flatpickr.js.org/plugins/#rangeplugin-beta) add a range selection using two inputs.
+It can be enabled in form generator or from dca:
+
+```php
+$GLOBALS['TL_DCA']['tl_content']['fields']['startDate']['eval']['flatpickr']['plugins']['rangePlugin'] = [
+    'input' => '#stopDate',
+];
 ```
 
 ## Developers

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "A bundle to provide flatpickr support for contao.",
   "license": "LGPL-3.0-or-later",
   "require": {
-    "php": "^7.4",
+    "php": "^7.4 || ^8.0",
     "contao/core-bundle": "^4.9",
     "heimrichhannot/contao-utils-bundle": "^2.206.0",
     "heimrichhannot/contao-twig-support-bundle": "^0.2.16 || ^1.0",

--- a/src/EventListener/FormGeneratorListener.php
+++ b/src/EventListener/FormGeneratorListener.php
@@ -37,6 +37,13 @@ class FormGeneratorListener
             return $widget;
         }
 
+        if (FormFieldModel::findBy(
+            ['pid=?','isFlatpickrDateRangeStartElement=\'1\'', 'flatpickrDateRangeStopElement=?' ],
+            [$widget->pid, $widget->id]
+        )) {
+            return $widget;
+        }
+
         $attributes = ['rgxp' => $widget->rgxp,];
 
         if ($widget->isFlatpickrDateRangeStartElement

--- a/src/EventListener/FormGeneratorListener.php
+++ b/src/EventListener/FormGeneratorListener.php
@@ -37,9 +37,16 @@ class FormGeneratorListener
             return $widget;
         }
 
-        $attributes = $this->flatpickrOptions->getWidgetAttributes([
-            'rgxp' => $widget->rgxp,
-        ]);
+        $attributes = ['rgxp' => $widget->rgxp,];
+
+        if ($widget->isFlatpickrDateRangeStartElement
+            && $widget->flatpickrDateRangeStopElement
+            && ($secondElement = FormFieldModel::findByPk((int)$widget->flatpickrDateRangeStopElement)))
+        {
+            $attributes['flatpickr']['plugins']['rangePlugin'] = ['input' => '#ctrl_'.$secondElement->id];
+        }
+
+        $attributes = $this->flatpickrOptions->getWidgetAttributes($attributes);
 
         $widget->addAttributes($attributes);
 

--- a/src/Option/FlatpickrOptions.php
+++ b/src/Option/FlatpickrOptions.php
@@ -38,12 +38,9 @@ class FlatpickrOptions
         ];
     }
 
-    public function getWidgetAttributes(array $attributes, DataContainer $dc = null, array $options = []): array
+    public function getWidgetAttributes(array $attributes, DataContainer $dc = null): array
     {
-        $pickerType    = $attributes['rgxp'];
-        $configuration = [];
-
-        $options = $this->getFlatpickrOptions($pickerType, $configuration);
+        $options = $this->getFlatpickrOptions($attributes['rgxp']);
         $options = array_merge($options, ($attributes['flatpickr']['options'] ?? []), $attributes['flatpickr']['plugins'] ?? []);
 
         $event = $this->eventDispatcher->dispatch(
@@ -62,7 +59,7 @@ class FlatpickrOptions
      * @param string $pickerType The Picker type, see class PICKER_TYPE_* constants.
      * @return array
      */
-    public function getFlatpickrOptions(string $pickerType = self::PICKER_TYPE_DATE,): array
+    public function getFlatpickrOptions(string $pickerType = self::PICKER_TYPE_DATE): array
     {
         $options = $this->getDefaultOptions();
 

--- a/src/Option/FlatpickrOptions.php
+++ b/src/Option/FlatpickrOptions.php
@@ -41,6 +41,14 @@ class FlatpickrOptions
     public function getWidgetAttributes(array $attributes, DataContainer $dc = null): array
     {
         $options = $this->getFlatpickrOptions($attributes['rgxp']);
+
+        if (isset($attributes['flatpickr']['options']['enableAmPm'])) {
+            trigger_deprecation('heimrichhannot/contao-flatpickr-bundle', '2.7', '\'enableAmPm\' option is deprecated and will not be supported in future versions. Please use time_24hr option instead.');
+            if (true === $attributes['flatpickr']['options']['enableAmPm']) {
+                $options['time_24hr'] = false;
+            }
+        }
+
         $options = array_merge($options, ($attributes['flatpickr']['options'] ?? []), $attributes['flatpickr']['plugins'] ?? []);
 
         $event = $this->eventDispatcher->dispatch(

--- a/src/Option/FlatpickrOptions.php
+++ b/src/Option/FlatpickrOptions.php
@@ -33,15 +33,18 @@ class FlatpickrOptions
             'wrap' => true,
             'time_24hr' => true,
             'allowInput' => true,
-            'dateFormat' => $GLOBALS['TL_CONFIG']['dateFormat'],
-            'dateFormatIso8601' => $this->dateUtil->transformPhpDateFormatToISO8601($GLOBALS['TL_CONFIG']['dateFormat'])
+            'dateFormat' => Date::getNumericDateFormat(),
+            'dateFormatIso8601' => $this->dateUtil->transformPhpDateFormatToISO8601(Date::getNumericDateFormat())
         ];
     }
 
-    public function getWidgetAttributes(array $attributes, DataContainer $dc = null): array
+    public function getWidgetAttributes(array $attributes, DataContainer $dc = null, array $options = []): array
     {
-        $options = $this->getFlatpickrOptions($attributes['rgxp']);
-        $options = array_merge($options, $attributes['flatpickr']['options'] ?? []);
+        $pickerType    = $attributes['rgxp'];
+        $configuration = [];
+
+        $options = $this->getFlatpickrOptions($pickerType, $configuration);
+        $options = array_merge($options, ($attributes['flatpickr']['options'] ?? []), $attributes['flatpickr']['plugins'] ?? []);
 
         $event = $this->eventDispatcher->dispatch(
             new CustomizeFlatpickrOptionsEvent($options, $attributes, $dc),
@@ -55,7 +58,11 @@ class FlatpickrOptions
         ];
     }
 
-    public function getFlatpickrOptions(string $pickerType = self::PICKER_TYPE_DATE): array
+    /**
+     * @param string $pickerType The Picker type, see class PICKER_TYPE_* constants.
+     * @return array
+     */
+    public function getFlatpickrOptions(string $pickerType = self::PICKER_TYPE_DATE,): array
     {
         $options = $this->getDefaultOptions();
 

--- a/src/Resources/contao/dca/tl_form_field.php
+++ b/src/Resources/contao/dca/tl_form_field.php
@@ -1,10 +1,26 @@
 <?php
 $dca = &$GLOBALS['TL_DCA']['tl_form_field'];
 
-$dca['fields']['addFlatpickrSupport'] = [
-    'label' => &$GLOBALS['TL_LANG']['tl_filter_config_element']['addFlatpickrSupport'],
-    'exclude' => true,
-    'inputType' => 'checkbox',
-    'eval' => ['tl_class' => 'w50'],
-    'sql' => "char(1) NOT NULL default ''",
-];
+$dca['palettes']['__selector__'][] = 'addFlatpickrSupport';
+$dca['palettes']['__selector__'][] = 'isFlatpickrDateRangeStartElement';
+
+$dca['subpalettes']['addFlatpickrSupport'] = 'isFlatpickrDateRangeStartElement';
+$dca['subpalettes']['isFlatpickrDateRangeStartElement'] = 'flatpickrDateRangeStopElement';
+
+$dca['fields'] = array_merge($dca['fields'], [
+    'addFlatpickrSupport' => [
+        'inputType' => 'checkbox',
+        'eval' => ['tl_class' => 'w50', 'submitOnChange' => true],
+        'sql' => "char(1) NOT NULL default ''",
+    ],
+    'isFlatpickrDateRangeStartElement' => [
+        'inputType' => 'checkbox',
+        'eval' => ['tl_class' => 'w50', 'submitOnChange' => true],
+        'sql' => "char(1) NOT NULL default ''",
+    ],
+    'flatpickrDateRangeStopElement' => [
+        'inputType'  => 'select',
+        'eval'       => ['tl_class' => 'w50', 'chosen' => true, 'includeBlankOption' => true],
+        'sql'        => "int(10) unsigned NOT NULL default 0",
+    ],
+]);

--- a/src/Resources/contao/languages/de/tl_form_field.php
+++ b/src/Resources/contao/languages/de/tl_form_field.php
@@ -1,5 +1,15 @@
 <?php
 $lang = &$GLOBALS['TL_LANG']['tl_form_field'];
 
-$lang['addFlatpickrSupport'][0] = 'Flatpickr aktivieren';
-$lang['addFlatpickrSupport'][1] = 'Wählen Sie diese Option, wenn diesem Feld eine Flatpickr-Datumsauswahl hinzugefügt werden soll.';
+$lang['addFlatpickrSupport'] = [
+    'Flatpickr aktivieren',
+    'Wählen Sie diese Option, wenn diesem Feld eine Flatpickr-Datumsauswahl hinzugefügt werden soll.'
+];
+$lang['isFlatpickrDateRangeStartElement'] = [
+    'Datumspanne-Start-Element',
+    'Dieses Element ist das Start-Element einer Datumsspanne.'
+];
+$lang['flatpickrDateRangeStopElement'] = [
+    'Datumspanne-End-Element',
+    'Wählen Sie hier das Datumsspanne-End-Element.'
+];


### PR DESCRIPTION
This PR add support for [rangePlugin](https://flatpickr.js.org/plugins/#rangeplugin-beta). 

It will be working from DCA and from Formgenerator.

Changelog:
- Added: support for rangePlugin (two input date range)
- Changed: refactored js code to reduce duplicate executions
- Changed: allow php 8
- Deprecated: enableAmPm support
- Fixed: enableAmPm support

ToDo:
- [x] Readme
- [x] Translation for Form generator fields